### PR TITLE
Require promise-returning functions when using the `concurrency` option in `PProgress.all()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,9 @@ class PProgress extends Promise {
 			Promise.resolve().then(() => {
 				if (progress === this._progress) {
 					return;
-				} else if (progress < this._progress) {
+				}
+
+				if (progress < this._progress) {
 					throw new Error('The progress percentage can\'t be lower than the last progress event');
 				}
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ class PProgress extends Promise {
 	}
 
 	static all(promises, options) {
+		if (typeof options === 'object' && typeof options['concurrency'] === 'number' && !(promises.every(p => typeof p === 'function'))) {
+			throw new TypeError('When `options.concurrency` is set, first argument must be an array of Promise returing functions')
+		}
+
 		return PProgress.fn(progress => {
 			const progressMap = new Map();
 			const iterator = promises[Symbol.iterator]();

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class PProgress extends Promise {
 	}
 
 	static all(promises, options) {
-		if (typeof options === 'object' && typeof options.concurrency === 'number' && !(promises.every(p => typeof p === 'function'))) {
+		if (options && typeof options.concurrency === 'number' && !(promises.every(p => typeof p === 'function'))) {
 			throw new TypeError('When `options.concurrency` is set, the first argument must be an Array of Promise-returning functions');
 		}
 

--- a/index.js
+++ b/index.js
@@ -31,7 +31,8 @@ class PProgress extends Promise {
 			};
 
 			const mapper = async () => {
-				const promise = iterator.next().value;
+				const next = iterator.next().value;
+				const promise = (typeof next === 'function') ? next() : next;
 				progressMap.set(promise, 0);
 
 				if (promise instanceof PProgress) {

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class PProgress extends Promise {
 
 			const mapper = async () => {
 				const next = iterator.next().value;
-				const promise = (typeof next === 'function') ? next() : next;
+				const promise = typeof next === 'function' ? next() : next;
 				progressMap.set(promise, 0);
 
 				if (promise instanceof PProgress) {

--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ class PProgress extends Promise {
 	}
 
 	static all(promises, options) {
-		if (typeof options === 'object' && typeof options['concurrency'] === 'number' && !(promises.every(p => typeof p === 'function'))) {
-			throw new TypeError('When `options.concurrency` is set, first argument must be an array of Promise returing functions')
+		if (typeof options === 'object' && typeof options.concurrency === 'number' && !(promises.every(p => typeof p === 'function'))) {
+			throw new TypeError('When `options.concurrency` is set, first argument must be an array of Promise returing functions');
 		}
 
 		return PProgress.fn(progress => {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class PProgress extends Promise {
 		return (...args) => {
 			return new PProgress((resolve, reject, progress) => {
 				args.push(progress);
-				input(...args).then(resolve, reject);
+				input(...args).then(resolve, reject); // eslint-disable-line promise/prefer-await-to-then
 			});
 		};
 	}
@@ -65,7 +65,7 @@ class PProgress extends Promise {
 			}
 
 			// We run this in the next microtask tick so `super` is called before we use `this`
-			Promise.resolve().then(() => {
+			Promise.resolve().then(() => { // eslint-disable-line promise/prefer-await-to-then
 				if (progress === this._progress) {
 					return;
 				}

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class PProgress extends Promise {
 
 	static all(promises, options) {
 		if (typeof options === 'object' && typeof options.concurrency === 'number' && !(promises.every(p => typeof p === 'function'))) {
-			throw new TypeError('When `options.concurrency` is set, first argument must be an array of Promise returing functions');
+			throw new TypeError('When `options.concurrency` is set, first argument must be an array of Promise returning functions');
 		}
 
 		return PProgress.fn(progress => {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class PProgress extends Promise {
 
 	static all(promises, options) {
 		if (typeof options === 'object' && typeof options.concurrency === 'number' && !(promises.every(p => typeof p === 'function'))) {
-			throw new TypeError('When `options.concurrency` is set, first argument must be an array of Promise returning functions');
+			throw new TypeError('When `options.concurrency` is set, the first argument must be an Array of Promise-returning functions');
 		}
 
 		return PProgress.fn(progress => {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
 	"devDependencies": {
 		"ava": "*",
 		"delay": "^2.0.0",
+		"in-range": "^1.0.0",
+		"time-span": "^2.0.0",
 		"xo": "*"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,7 @@ Number of concurrently pending promises.
 
 To run the promises in series, set it to `1`.
 
-When this option is set, the `promises` argument argument must be an array of promise-returning functions.
+When this option is set, the first argument must be an array of promise-returning functions.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,7 @@ Number of concurrently pending promises.
 
 To run the promises in series, set it to `1`.
 
+> When `concurrency` is set, first argument must be an array of Promise returning functions
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ const allProgressPromise = PProgress.all([
 
 Type: `Array`
 
-Array of promises or promise returning functions, similar to [p-series](https://github.com/sindresorhus/p-series).
+Array of promises or promise returning functions, similar to [p-all](https://github.com/sindresorhus/p-all).
 
 #### options
 

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ const allProgressPromise = PProgress.all([
 
 Type: `Array`
 
-Array of promises or promise returning functions, similar to [p-all](https://github.com/sindresorhus/p-all).
+Array of promises or promise-returning functions, similar to [p-all](https://github.com/sindresorhus/p-all).
 
 #### options
 
@@ -161,7 +161,8 @@ Number of concurrently pending promises.
 
 To run the promises in series, set it to `1`.
 
-> When `concurrency` is set, first argument must be an array of Promise returning functions
+When this option is set, the `promises` argument argument must be an array of promise-returning functions.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -145,7 +145,7 @@ const allProgressPromise = PProgress.all([
 
 Type: `Array`
 
-Array of promises.
+Array of promises or promise returning functions, similar to [p-series](https://github.com/sindresorhus/p-series).
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -121,7 +121,7 @@ test('PProgress.all() with concurrency = 1', async t => {
 		return input;
 	});
 
-	// Should throw when first argument is array of Promises instead of promise-returning functions
+	// Should throw when first argument is array of promises instead of promise-returning functions
 	t.throws(() => PProgress.all([fixtureFn(fixture), fixtureFn2(fixture)], {
 		concurrency: 1
 	}), TypeError);

--- a/test.js
+++ b/test.js
@@ -1,5 +1,7 @@
 import test from 'ava';
 import delay from 'delay';
+import timeSpan from 'time-span';
+import inRange from 'in-range';
 import PProgress from '.';
 
 const fixture = Symbol('fixture');
@@ -100,4 +102,46 @@ test('PProgress.all()', async t => {
 		undefined,
 		undefined
 	]);
+});
+
+test('PProgress.all() with concurrency = 1', async t => {
+	const fixtureFn = PProgress.fn(async (input, progress) => {
+		progress(0.16);
+		await delay(50);
+		progress(0.55);
+		await delay(50);
+		return input;
+	});
+
+	const fixtureFn2 = PProgress.fn(async (input, progress) => {
+		progress(0.41);
+		await delay(50);
+		progress(0.93);
+		await delay(50);
+		return input;
+	});
+
+	// Should throw when first argument is array of Promises instead of promise-returning functions
+	t.throws(() => PProgress.all([fixtureFn(fixture), fixtureFn2(fixture)], {
+		concurrency: 1
+	}), TypeError);
+
+	const end = timeSpan();
+	const p = PProgress.all([
+		() => fixtureFn(fixture),
+		() => fixtureFn2(fixture)
+	], {
+		concurrency: 1
+	});
+
+	p.onProgress(progress => {
+		t.true(progress >= 0 && progress <= 1);
+	});
+
+	t.deepEqual(await p, [
+		fixture,
+		fixture
+	]);
+
+	t.true(inRange(end(), 200 /* 4 delays of 50ms each */, 250 /* reasonable padding */));
 });


### PR DESCRIPTION
Similar to `pSeries`.

When setting `concurrency = 1` a user would expect a task to be called after previous has finished (resolved).
Without being able to pass a function they all get "called" at once, defeating the "series" claim.

Fixes #4