### PR TITLE
Do not throw if a progress is less than last value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -762,7 +762,8 @@ declare class PProgress<ValueType> extends Promise<ValueType> {
 		/**
 		@param progress - Call this with progress updates. It expects a number between 0 and 1.
 
-		Multiple calls with the same number will result in only one `onProgress()` event.
+		Multiple calls with the same number will result in only one `onProgress()`
+		event. Calling with a number lower than previously will be ignored.
 
 		Progress percentage `1` is reported for you when the promise resolves. If you set it yourself, it will simply be ignored.
 		*/

--- a/index.js
+++ b/index.js
@@ -75,9 +75,9 @@ class PProgress extends Promise {
 				// We wait for the next microtask tick so `super` is called before we use `this`
 				await Promise.resolve();
 
-                               // Note: we don't really have guarantees over
-                               // the order in which async operations are evaluated,
-                               // so if we get an out-of-order progress, we'll just discard it.
+				// Note: we don't really have guarantees over
+				// the order in which async operations are evaluated,
+				// so if we get an out-of-order progress, we'll just discard it.
 				if (progress <= this._progress) {
 					return;
 				}

--- a/index.js
+++ b/index.js
@@ -75,12 +75,11 @@ class PProgress extends Promise {
 				// We wait for the next microtask tick so `super` is called before we use `this`
 				await Promise.resolve();
 
-				if (progress === this._progress) {
+                               // Note: we don't really have guarantees over
+                               // the order in which async operations are evaluated,
+                               // so if we get an out-of-order progress, we'll just discard it.
+				if (progress <= this._progress) {
 					return;
-				}
-
-				if (progress < this._progress) {
-					throw new Error('The progress percentage can\'t be lower than the last progress event');
 				}
 
 				this._progress = progress;

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,8 @@ Type: `Function`
 
 Call this with progress updates. It expects a number between 0 and 1.
 
-Multiple calls with the same number will result in only one `onProgress()` event.
+Multiple calls with the same number will result in only one `onProgress()`
+event. Calling with a number lower than previously will be ignored.
 
 Progress percentage `1` is reported for you when the promise resolves. If you set it yourself, it will simply be ignored.
 


### PR DESCRIPTION
Since you can't guarantee that async stuff will evaluate in order, it's conceivable that event handlers may be evaluated out of order (I've noticed this in a browser after tabbing away and coming back.)

Fixes https://github.com/sindresorhus/p-progress/issues/8