### PR TITLE
Return `PProgress` instance for Promise methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,8 +125,11 @@ class PProgress extends Promise {
 
 	then(onFulfilled, onRejected) {
 		// eslint-disable-next-line promise/prefer-await-to-then
-		super.then(onFulfilled, onRejected);
-		return this;
+		const child = super.then(onFulfilled, onRejected);
+		this._listeners.add(progress => {
+			child._setProgress(progress);
+		});
+		return child;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -122,6 +122,12 @@ class PProgress extends Promise {
 		this._listeners.add(callback);
 		return this;
 	}
+
+	then(onFulfilled, onRejected) {
+		// eslint-disable-next-line promise/prefer-await-to-then
+		super.then(onFulfilled, onRejected);
+		return this;
+	}
 }
 
 module.exports = PProgress;

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ import PProgress from '.';
 const fixture = Symbol('fixture');
 
 test('new PProgress()', async t => {
-	t.plan(42);
+	t.plan(45);
 
 	const p = new PProgress(async (resolve, reject, progress) => {
 		progress(0.1);
@@ -37,10 +37,14 @@ test('new PProgress()', async t => {
 	});
 
 	// eslint-disable-next-line promise/prefer-await-to-then
-	p.then(() => {}).onProgress(progress => {
-		t.is(progress, p.progress);
-		t.true(progress >= 0 && progress <= 1);
-	});
+	p.then(result => [result, result]).then(results => {
+		t.true(Array.isArray(results));
+		results.forEach(result => t.is(result, fixture));
+	})
+		.onProgress(progress => {
+			t.is(progress, p.progress);
+			t.true(progress >= 0 && progress <= 1);
+		});
 
 	p.catch(() => {}).onProgress(progress => {
 		t.is(progress, p.progress);

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ import PProgress from '.';
 const fixture = Symbol('fixture');
 
 test('new PProgress()', async t => {
-	t.plan(52);
+	t.plan(42);
 
 	const p = new PProgress(async (resolve, reject, progress) => {
 		progress(0.1);
@@ -43,11 +43,6 @@ test('new PProgress()', async t => {
 	});
 
 	p.catch(() => {}).onProgress(progress => {
-		t.is(progress, p.progress);
-		t.true(progress >= 0 && progress <= 1);
-	});
-
-	p.finally(() => {}).onProgress(progress => {
 		t.is(progress, p.progress);
 		t.true(progress >= 0 && progress <= 1);
 	});

--- a/test.js
+++ b/test.js
@@ -52,6 +52,7 @@ test('new PProgress()', async t => {
 	});
 
 	t.is(await p, fixture);
+	await delay(1);
 });
 
 test('PProgress.fn()', async t => {

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ import PProgress from '.';
 const fixture = Symbol('fixture');
 
 test('new PProgress()', async t => {
-	t.plan(22);
+	t.plan(52);
 
 	const p = new PProgress(async (resolve, reject, progress) => {
 		progress(0.1);
@@ -32,6 +32,22 @@ test('new PProgress()', async t => {
 	});
 
 	p.onProgress(progress => {
+		t.is(progress, p.progress);
+		t.true(progress >= 0 && progress <= 1);
+	});
+
+	// eslint-disable-next-line promise/prefer-await-to-then
+	p.then(() => {}).onProgress(progress => {
+		t.is(progress, p.progress);
+		t.true(progress >= 0 && progress <= 1);
+	});
+
+	p.catch(() => {}).onProgress(progress => {
+		t.is(progress, p.progress);
+		t.true(progress >= 0 && progress <= 1);
+	});
+
+	p.finally(() => {}).onProgress(progress => {
 		t.is(progress, p.progress);
 		t.true(progress >= 0 && progress <= 1);
 	});


### PR DESCRIPTION
Ensures the current PProgress instance is returned from then/catch/finally.

closes #11 