### PR TITLE
Add example with `PProgress.fn` to "usage"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,29 @@ const PProgress = require('p-progress');
 
 	await progressPromise;
 })();
+
+(async () => {
+	const doTheThings = PProgress.fn(async progress => {
+		await doFirstThing();
+		progress(0.2);
+		await doSecondThing();
+		progress(0.7);
+		await doLastThing();
+		return 'done!';
+	});
+
+	const progressPromise = doTheThings();
+
+	progressPromise.onProgress(progress => {
+		console.log(`${progress * 100}%`);
+		//=> 20%
+		//=> 70%
+		//=> 100%
+	});
+
+	console.log(await progressPromise);
+	//=> 'done!'
+})();
 ```
 
 ## API


### PR DESCRIPTION
The `PProgress.fn` is very useful, perhaps even more than calling `new PProgress` manually, I think it deserves a direct example in the Usage section of the readme.

This may also help #14, ping @ctrngk