### PR TITLE
Fix the TypeScript type for `pProgress.all`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -717,12 +717,12 @@ declare class PProgress<ValueType> extends Promise<ValueType> {
 	static all<AllValuesType>(
 		promises: Iterable<PProgress.PromiseFactory<AllValuesType>>,
 		options: PProgress.Options
-	): PProgress<AllValuesType>;
+	): PProgress<Iterable<AllValuesType>>;
 	static all<AllValuesType>(
 		promises: Iterable<
 			PromiseLike<AllValuesType> | PProgress.PromiseFactory<AllValuesType>
 		>
-	): PProgress<AllValuesType>;
+	): PProgress<Iterable<AllValuesType>>;
 
 	/**
 	Same as the [`Promise` constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise).

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -635,7 +635,7 @@ expectType<
 	)
 );
 
-expectType<PProgress<string | number | boolean | symbol | string[]>>(
+expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>([
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
@@ -650,7 +650,7 @@ expectType<PProgress<string | number | boolean | symbol | string[]>>(
 		Promise.resolve(['foo'])
 	])
 );
-expectType<PProgress<string | number | boolean | symbol | string[]>>(
+expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>([
 		() => Promise.resolve('sindresorhus.com'),
 		() => Promise.resolve(1),
@@ -665,7 +665,7 @@ expectType<PProgress<string | number | boolean | symbol | string[]>>(
 		() => Promise.resolve(['foo'])
 	])
 );
-expectType<PProgress<string | number | boolean | symbol | string[]>>(
+expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>(
 		[
 			() => Promise.resolve('sindresorhus.com'),
@@ -684,7 +684,7 @@ expectType<PProgress<string | number | boolean | symbol | string[]>>(
 	)
 );
 
-expectType<PProgress<string | number | boolean | symbol | string[]>>(
+expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>(
 		new Set([
 			Promise.resolve('sindresorhus.com'),
@@ -701,7 +701,7 @@ expectType<PProgress<string | number | boolean | symbol | string[]>>(
 		])
 	)
 );
-expectType<PProgress<string | number | boolean | symbol | string[]>>(
+expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>(
 		new Set([
 			() => Promise.resolve('sindresorhus.com'),
@@ -718,7 +718,7 @@ expectType<PProgress<string | number | boolean | symbol | string[]>>(
 		])
 	)
 );
-expectType<PProgress<string | number | boolean | symbol | string[]>>(
+expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>(
 		new Set([
 			() => Promise.resolve('sindresorhus.com'),


### PR DESCRIPTION
Fixes #17

`pProgress.all` maps over its input - so the return type should also be an iterable.