### PR TITLE
Require Node.js 12.2, rework `.fn` to `pProgress` and export `PProgress` as a named export

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,6 @@ jobs:
         node-version:
           - 14
           - 12
-          - 10
-          - 8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/example.js
+++ b/example.js
@@ -1,8 +1,7 @@
-'use strict';
-const delay = require('delay');
-const PProgress = require('.');
+import pProgress, {PProgress} from 'p-progress';
+import delay from 'delay';
 
-const progressPromise = PProgress.fn(async progress => {
+const progressPromise = () => pProgress(async progress => {
 	progress(0.14);
 	await delay(52);
 	progress(0.37);
@@ -20,8 +19,6 @@ const allProgressPromise = PProgress.all([
 	delay(209)
 ]);
 
-(async () => {
-	allProgressPromise.onProgress(console.log);
+allProgressPromise.onProgress(console.log);
 
-	await allProgressPromise;
-})();
+await allProgressPromise;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,66 +1,77 @@
 type Awaited<ValueType> = ValueType extends undefined ? ValueType : ValueType extends PromiseLike<infer ResolveValueType> ? ResolveValueType : ValueType;
 
-declare namespace PProgress {
-	interface Options {
-		/**
-		Number of concurrently pending promises. Minimum: `1`.
+export interface Options {
+	/**
+	Number of concurrently pending promises. Minimum: `1`.
 
-		To run the promises in series, set it to `1`.
+	To run the promises in series, set it to `1`.
 
-		When this option is set, the first argument must be an array of promise-returning functions.
+	When this option is set, the first argument must be an array of promise-returning functions.
 
-		@default Infinity
-		*/
-		readonly concurrency: number;
-	}
-
-	type PromiseFactory<ValueType> = () => PromiseLike<ValueType>;
-	type ProgressNotifier = (progress: number) => void;
+	@default Infinity
+	*/
+	readonly concurrency: number;
 }
 
-// @ts-ignore `Promise.all` currently uses an incompatible combinatorics-based type definition (https://github.com/microsoft/TypeScript/issues/39788)
-declare class PProgress<ValueType> extends Promise<ValueType> {
+export type PromiseFactory<ValueType> = () => PromiseLike<ValueType>;
+
+export type ProgressNotifier = (progress: number) => void;
+
+// @ts-expect-error `Promise.all` currently uses an incompatible combinatorics-based type definition (https://github.com/microsoft/TypeScript/issues/39788)
+export class PProgress<ValueType> extends Promise<ValueType> {
 	/**
 	The current progress percentage of the promise as a number between 0 and 1.
 	*/
 	readonly progress: number;
 
 	/**
-	Convenience method to make your promise-returning or async function report progress.
+	Same as the [`Promise` constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
-	The function you specify will have the `progress()` function appended to its parameters.
+	@param executor - Same as the `Promise` constructor but with an appended `progress` parameter in `executor`.
 
 	@example
 	```
-	import PProgress = require('p-progress');
+	import {PProgress} from 'p-progress';
 
-	const runJob = PProgress.fn(async (name, progress) => {
-		const job = new Job(name);
+	const progressPromise = new PProgress((resolve, reject, progress) => {
+		const job = new Job();
 
 		job.on('data', data => {
 			progress(data.length / job.totalSize);
 		});
 
-		await job.run();
+		job.on('finish', resolve);
+		job.on('error', reject);
 	});
 
-	(async () => {
-		const progressPromise = runJob('Gather rainbows');
+	progressPromise.onProgress(progress => {
+		console.log(`${progress * 100}%`);
+		//=> 9%
+		//=> 23%
+		//=> 59%
+		//=> 75%
+		//=> 100%
+	});
 
-		progressPromise.onProgress(console.log);
-		//=> 0.09
-		//=> 0.23
-		//=> 0.59
-		//=> 0.75
-		//=> 1
-
-		await progressPromise;
-	})();
+	await progressPromise;
 	```
 	*/
-	static fn<ReturnType, Arguments extends unknown[]>(
-		input: (...arguments_: [...arguments_: Arguments, progress: PProgress.ProgressNotifier]) => PromiseLike<ReturnType> | ReturnType
-	): (...arguments_: Arguments) => PProgress<ReturnType>;
+	constructor(
+		/**
+		@param progress - Call this with progress updates. It expects a number between 0 and 1.
+
+		Multiple calls with the same number will result in only one `onProgress()` event.
+
+		Calling with a number lower than previously will be ignored.
+
+		Progress percentage `1` is reported for you when the promise resolves. If you set it yourself, it will simply be ignored.
+		*/
+		executor: (
+			resolve: (value?: ValueType | PromiseLike<ValueType>) => void,
+			reject: (reason?: unknown) => void,
+			progress: ProgressNotifier
+		) => void
+	);
 
 	/**
 	Convenience method to run multiple promises and get a total progress of all of them. It counts normal promises with progress `0` when pending and progress `1` when resolved. For `PProgress` type promises, it listens to their `onProgress()` method for more fine grained progress reporting. You can mix and match normal promises and `PProgress` promises.
@@ -69,10 +80,10 @@ declare class PProgress<ValueType> extends Promise<ValueType> {
 
 	@example
 	```
-	import PProgress = require('p-progress');
-	import delay = require('delay');
+	import pProgress, {PProgress} from 'p-progress';
+	import delay from 'delay';
 
-	const progressPromise = PProgress.fn(async progress => {
+	const progressPromise = () => pProgress(async progress => {
 		progress(0.14);
 		await delay(52);
 		progress(0.37);
@@ -90,29 +101,27 @@ declare class PProgress<ValueType> extends Promise<ValueType> {
 		delay(209)
 	]);
 
-	(async () => {
-		allProgressPromise.onProgress(console.log);
-		//=> 0.0925
-		//=> 0.3425
-		//=> 0.5925
-		//=> 0.6025
-		//=> 0.7325
-		//=> 0.9825
-		//=> 1
+	allProgressPromise.onProgress(console.log);
+	//=> 0.0925
+	//=> 0.3425
+	//=> 0.5925
+	//=> 0.6025
+	//=> 0.7325
+	//=> 0.9825
+	//=> 1
 
-		await allProgressPromise;
-	})();
+	await allProgressPromise;
 	```
 	*/
-	static all<Promises extends Array<PProgress.PromiseFactory<unknown> | PromiseLike<unknown>>>(
+	static all<Promises extends Array<PromiseFactory<unknown> | PromiseLike<unknown>>>(
 		promises: readonly [...Promises],
-		options?: PProgress.Options
+		options?: Options
 	): PProgress<{
 		[Promise_ in keyof Promises]: (
 			Promises[Promise_] extends PromiseLike<unknown>
 				? Awaited<Promises[Promise_]>
 				: (
-					Promises[Promise_] extends PProgress.PromiseFactory<unknown>
+					Promises[Promise_] extends PromiseFactory<unknown>
 						? Awaited<ReturnType<Promises[Promise_]>>
 						: Promises[Promise_]
 				)
@@ -120,65 +129,45 @@ declare class PProgress<ValueType> extends Promise<ValueType> {
 
 	}>;
 	static all<ReturnValue>(
-		promises: Iterable<PProgress.PromiseFactory<ReturnValue> | PromiseLike<ReturnValue>>,
-		options?: PProgress.Options
+		promises: Iterable<PromiseFactory<ReturnValue> | PromiseLike<ReturnValue>>,
+		options?: Options
 	): PProgress<Iterable<ReturnValue>>;
-
-	/**
-	Same as the [`Promise` constructor](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise).
-
-	@param executor - Same as the `Promise` constructor but with an appended `progress` parameter in `executor`.
-
-	@example
-	```
-	import PProgress = require('p-progress');
-
-	const progressPromise = new PProgress((resolve, reject, progress) => {
-		const job = new Job();
-
-		job.on('data', data => {
-			progress(data.length / job.totalSize);
-		});
-
-		job.on('finish', resolve);
-		job.on('error', reject);
-	});
-
-	(async () => {
-		progressPromise.onProgress(progress => {
-			console.log(`${progress * 100}%`);
-			//=> 9%
-			//=> 23%
-			//=> 59%
-			//=> 75%
-			//=> 100%
-		});
-
-		await progressPromise;
-	})();
-	```
-	*/
-	constructor(
-		/**
-		@param progress - Call this with progress updates. It expects a number between 0 and 1.
-
-		Multiple calls with the same number will result in only one `onProgress()` event.
-
-		Calling with a number lower than previously will be ignored.
-
-		Progress percentage `1` is reported for you when the promise resolves. If you set it yourself, it will simply be ignored.
-		*/
-		executor: (
-			resolve: (value?: ValueType | PromiseLike<ValueType>) => void,
-			reject: (reason?: unknown) => void,
-			progress: PProgress.ProgressNotifier
-		) => void
-	);
 
 	/**
 	Accepts a function that gets `instance.progress` as an argument and is called for every progress event.
 	*/
-	onProgress(callback: PProgress.ProgressNotifier): void;
+	onProgress(callback: ProgressNotifier): void;
 }
 
-export = PProgress;
+/**
+Convenience method to make your promise-returning or async function report progress.
+
+The function you specify will be passed the `progress()` function as a parameter.
+
+@example
+```
+import pProgress from 'p-progress';
+
+const runJob = async name => pProgress(async progress => {
+	const job = new Job(name);
+
+	job.on('data', data => {
+		progress(data.length / job.totalSize)
+	});
+
+	await job.run()
+});
+
+const progressPromise = runJob('Gather rainbows');
+
+progressPromise.onProgress(console.log);
+//=> 0.09
+//=> 0.23
+//=> 0.59
+//=> 0.75
+//=> 1
+
+await progressPromise;
+```
+*/
+export default function pProgress<ReturnValue>(input: (progress: ProgressNotifier) => PromiseLike<ReturnValue> | ReturnValue): PProgress<ReturnValue>;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-'use strict';
-const pTimes = require('p-times');
+import pTimes from 'p-times';
 
 const sum = iterable => {
 	let total = 0;
@@ -11,20 +10,7 @@ const sum = iterable => {
 	return total;
 };
 
-class PProgress extends Promise {
-	static fn(input) {
-		return (...arguments_) => {
-			return new PProgress(async (resolve, reject, progress) => {
-				arguments_.push(progress);
-				try {
-					resolve(await input(...arguments_));
-				} catch (error) {
-					reject(error);
-				}
-			});
-		};
-	}
-
+export class PProgress extends Promise {
 	static all(promises, options) {
 		if (
 			options && typeof options.concurrency === 'number' &&
@@ -33,7 +19,7 @@ class PProgress extends Promise {
 			throw new TypeError('When `options.concurrency` is set, the first argument must be an Array of Promise-returning functions');
 		}
 
-		return PProgress.fn(progress => {
+		return pProgress(progress => {
 			const progressMap = new Map();
 
 			const reportProgress = () => {
@@ -59,7 +45,7 @@ class PProgress extends Promise {
 			};
 
 			return pTimes(promises.length, mapper, options);
-		})();
+		});
 	}
 
 	constructor(executor) {
@@ -130,4 +116,12 @@ class PProgress extends Promise {
 	}
 }
 
-module.exports = PProgress;
+const pProgress = input => new PProgress(async (resolve, reject, progress) => {
+	try {
+		resolve(await input(progress));
+	} catch (error) {
+		reject(error);
+	}
+});
+
+export default pProgress;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,5 @@
 import {expectType} from 'tsd';
-import PProgress = require('.');
-import {ProgressNotifier} from '.';
+import pProgress, {PProgress, ProgressNotifier} from './index.js';
 
 const progressPromise = new PProgress(async (resolve, reject, progress) => {
 	expectType<(progress: number) => void>(progress);
@@ -11,251 +10,12 @@ progressPromise.onProgress(progress => {
 });
 expectType<number>(progressPromise.progress);
 
-// PProgress.fn
-expectType<() => PProgress<boolean>>(
-	PProgress.fn(async progress => {
+// PProgress
+expectType<PProgress<boolean>>(
+	pProgress(async (progress: ProgressNotifier) => {
 		expectType<(progress: number) => void>(progress);
 		return true;
 	})
-);
-expectType<(string: string) => PProgress<boolean>>(
-	PProgress.fn(async (string: string, progress: ProgressNotifier) => {
-		expectType<(progress: number) => void>(progress);
-		return true;
-	})
-);
-expectType<(string: string, boolean: boolean) => PProgress<boolean>>(
-	PProgress.fn(
-		async (string: string, boolean: boolean, progress: ProgressNotifier) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(string: string, boolean: boolean, number: number) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol,
-		array: string[]
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol,
-		array: string[],
-		string2: string
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			string2: string,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol,
-		array: string[],
-		string2: string,
-		boolean2: boolean
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			string2: string,
-			boolean2: boolean,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol,
-		array: string[],
-		string2: string,
-		boolean2: boolean,
-		number2: number
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			string2: string,
-			boolean2: boolean,
-			number2: number,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol,
-		array: string[],
-		string2: string,
-		boolean2: boolean,
-		number2: number,
-		symbol2: symbol
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			string2: string,
-			boolean2: boolean,
-			number2: number,
-			symbol2: symbol,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<
-	(
-		string: string,
-		boolean: boolean,
-		number: number,
-		symbol: symbol,
-		array: string[],
-		string2: string,
-		boolean2: boolean,
-		number2: number,
-		symbol2: symbol,
-		array2: string[]
-	) => PProgress<boolean>
->(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			string2: string,
-			boolean2: boolean,
-			number2: number,
-			symbol2: symbol,
-			array2: string[],
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
-);
-expectType<(string: string, boolean: boolean, number: number, symbol: symbol, array: string[], string2: string, boolean2: boolean, number2: number, symbol2: symbol, array2: string[], string3: string) => PProgress<boolean>>(
-	PProgress.fn(
-		async (
-			string: string,
-			boolean: boolean,
-			number: number,
-			symbol: symbol,
-			array: string[],
-			string2: string,
-			boolean2: boolean,
-			number2: number,
-			symbol2: symbol,
-			array2: string[],
-			string3: string,
-			progress: ProgressNotifier
-		) => {
-			expectType<(progress: number) => void>(progress);
-			return true;
-		}
-	)
 );
 
 // PProgress.all
@@ -263,23 +23,23 @@ expectType<PProgress<[string]>>(
 	PProgress.all([Promise.resolve('sindresorhus.com')])
 );
 expectType<PProgress<[string]>>(
-	PProgress.all([() => Promise.resolve('sindresorhus.com')])
+	PProgress.all([async () => Promise.resolve('sindresorhus.com')])
 );
 expectType<PProgress<[string]>>(
-	PProgress.all([() => Promise.resolve('sindresorhus.com')], {concurrency: 1})
+	PProgress.all([async () => Promise.resolve('sindresorhus.com')], {concurrency: 1})
 );
 expectType<PProgress<[string, number]>>(
 	PProgress.all([Promise.resolve('sindresorhus.com'), Promise.resolve(1)])
 );
 expectType<PProgress<[string, number]>>(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1)
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1)
 	])
 );
 expectType<PProgress<[string, number]>>(
 	PProgress.all(
-		[() => Promise.resolve('sindresorhus.com'), () => Promise.resolve(1)],
+		[async () => Promise.resolve('sindresorhus.com'), async () => Promise.resolve(1)],
 		{concurrency: 1}
 	)
 );
@@ -292,17 +52,17 @@ expectType<PProgress<[string, number, boolean]>>(
 );
 expectType<PProgress<[string, number, boolean]>>(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true)
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true)
 	])
 );
 expectType<PProgress<[string, number, boolean]>>(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true)
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true)
 		],
 		{concurrency: 1}
 	)
@@ -312,24 +72,24 @@ expectType<PProgress<[string, number, boolean, symbol]>>(
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol())
+		Promise.resolve(Symbol('Test'))
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol]>>(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol())
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test'))
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol]>>(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol())
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test'))
 		],
 		{concurrency: 1}
 	)
@@ -339,27 +99,27 @@ expectType<PProgress<[string, number, boolean, symbol, string[]]>>(
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo'])
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol, string[]]>>(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo'])
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo'])
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol, string[]]>>(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo'])
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo'])
 		],
 		{concurrency: 1}
 	)
@@ -369,86 +129,86 @@ expectType<PProgress<[string, number, boolean, symbol, string[], string]>>(
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve('sindresorhus.com')
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol, string[], string]>>(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve('sindresorhus.com')
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve('sindresorhus.com')
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol, string[], string]>>(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com')
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com')
 		],
 		{concurrency: 1}
 	)
 );
 expectType<
-	PProgress<[string, number, boolean, symbol, string[], string, number]>
+PProgress<[string, number, boolean, symbol, string[], string, number]>
 >(
 	PProgress.all([
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1)
 	])
 );
 expectType<
-	PProgress<[string, number, boolean, symbol, string[], string, number]>
+PProgress<[string, number, boolean, symbol, string[], string, number]>
 >(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1)
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1)
 	])
 );
 expectType<
-	PProgress<[string, number, boolean, symbol, string[], string, number]>
+PProgress<[string, number, boolean, symbol, string[], string, number]>
 >(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1)
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1)
 		],
 		{concurrency: 1}
 	)
 );
 expectType<
-	PProgress<
-		[string, number, boolean, symbol, string[], string, number, boolean]
-	>
+PProgress<
+[string, number, boolean, symbol, string[], string, number, boolean]
+>
 >(
 	PProgress.all([
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
@@ -456,180 +216,180 @@ expectType<
 	])
 );
 expectType<
-	PProgress<
-		[string, number, boolean, symbol, string[], string, number, boolean]
-	>
+PProgress<
+[string, number, boolean, symbol, string[], string, number, boolean]
+>
 >(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true)
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true)
 	])
 );
 expectType<
-	PProgress<
-		[string, number, boolean, symbol, string[], string, number, boolean]
-	>
+PProgress<
+[string, number, boolean, symbol, string[], string, number, boolean]
+>
 >(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true)
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true)
 		],
 		{concurrency: 1}
 	)
 );
 expectType<
-	PProgress<
-		[string, number, boolean, symbol, string[], string, number, boolean, symbol]
-	>
+PProgress<
+[string, number, boolean, symbol, string[], string, number, boolean, symbol]
+>
 >(
 	PProgress.all([
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol())
+		Promise.resolve(Symbol('Test'))
 	])
 );
 expectType<
-	PProgress<
-		[string, number, boolean, symbol, string[], string, number, boolean, symbol]
-	>
+PProgress<
+[string, number, boolean, symbol, string[], string, number, boolean, symbol]
+>
 >(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol())
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test'))
 	])
 );
 expectType<
-	PProgress<
-		[string, number, boolean, symbol, string[], string, number, boolean, symbol]
-	>
+PProgress<
+[string, number, boolean, symbol, string[], string, number, boolean, symbol]
+>
 >(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol())
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test'))
 		],
 		{concurrency: 1}
 	)
 );
 expectType<
-	PProgress<
-		[
-			string,
-			number,
-			boolean,
-			symbol,
-			string[],
-			string,
-			number,
-			boolean,
-			symbol,
-			string[]
-		]
-	>
+PProgress<
+[
+	string,
+	number,
+	boolean,
+	symbol,
+	string[],
+	string,
+	number,
+	boolean,
+	symbol,
+	string[]
+]
+>
 >(
 	PProgress.all([
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo'])
 	])
 );
 expectType<
-	PProgress<
-		[
-			string,
-			number,
-			boolean,
-			symbol,
-			string[],
-			string,
-			number,
-			boolean,
-			symbol,
-			string[]
-		]
-	>
+PProgress<
+[
+	string,
+	number,
+	boolean,
+	symbol,
+	string[],
+	string,
+	number,
+	boolean,
+	symbol,
+	string[]
+]
+>
 >(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo'])
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo'])
 	])
 );
 expectType<
-	PProgress<
-		[
-			string,
-			number,
-			boolean,
-			symbol,
-			string[],
-			string,
-			number,
-			boolean,
-			symbol,
-			string[]
-		]
-	>
+PProgress<
+[
+	string,
+	number,
+	boolean,
+	symbol,
+	string[],
+	string,
+	number,
+	boolean,
+	symbol,
+	string[]
+]
+>
 >(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo'])
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo'])
 		],
 		{concurrency: 1}
 	)
@@ -640,45 +400,45 @@ expectType<PProgress<[string, number, boolean, symbol, string[], string, number,
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve('sindresorhus.com'),
 		Promise.resolve(1),
 		Promise.resolve(true),
-		Promise.resolve(Symbol()),
+		Promise.resolve(Symbol('Test')),
 		Promise.resolve(['foo']),
 		Promise.resolve(['foo'])
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol, string[], string, number, boolean, symbol, string[], string[]]>>(
 	PProgress.all([
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve('sindresorhus.com'),
-		() => Promise.resolve(1),
-		() => Promise.resolve(true),
-		() => Promise.resolve(Symbol()),
-		() => Promise.resolve(['foo']),
-		() => Promise.resolve(['foo'])
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve('sindresorhus.com'),
+		async () => Promise.resolve(1),
+		async () => Promise.resolve(true),
+		async () => Promise.resolve(Symbol('Test')),
+		async () => Promise.resolve(['foo']),
+		async () => Promise.resolve(['foo'])
 	])
 );
 expectType<PProgress<[string, number, boolean, symbol, string[], string, number, boolean, symbol, string[], string[]]>>(
 	PProgress.all(
 		[
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve(['foo'])
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve(['foo'])
 		],
 		{concurrency: 1}
 	)
@@ -690,12 +450,12 @@ expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 			Promise.resolve('sindresorhus.com'),
 			Promise.resolve(1),
 			Promise.resolve(true),
-			Promise.resolve(Symbol()),
+			Promise.resolve(Symbol('Test')),
 			Promise.resolve(['foo']),
 			Promise.resolve('sindresorhus.com'),
 			Promise.resolve(1),
 			Promise.resolve(true),
-			Promise.resolve(Symbol()),
+			Promise.resolve(Symbol('Test')),
 			Promise.resolve(['foo']),
 			Promise.resolve(['foo'])
 		])
@@ -704,34 +464,34 @@ expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>(
 		new Set([
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve(['foo'])
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve(['foo'])
 		])
 	)
 );
 expectType<PProgress<Iterable<string | number | boolean | symbol | string[]>>>(
 	PProgress.all<string | number | boolean | symbol | string[]>(
 		new Set([
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve('sindresorhus.com'),
-			() => Promise.resolve(1),
-			() => Promise.resolve(true),
-			() => Promise.resolve(Symbol()),
-			() => Promise.resolve(['foo']),
-			() => Promise.resolve(['foo'])
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve('sindresorhus.com'),
+			async () => Promise.resolve(1),
+			async () => Promise.resolve(true),
+			async () => Promise.resolve(Symbol('Test')),
+			async () => Promise.resolve(['foo']),
+			async () => Promise.resolve(['foo'])
 		]),
 		{concurrency: 1}
 	)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
 		"email": "sindresorhus@gmail.com",
 		"url": "https://sindresorhus.com"
 	},
+	"type": "module",
+	"exports": "./index.js",
 	"engines": {
-		"node": ">=8"
+		"node": ">=12.2"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -35,11 +37,24 @@
 		"p-times": "^3.0.0"
 	},
 	"devDependencies": {
-		"ava": "^2.2.0",
-		"delay": "^4.1.0",
-		"in-range": "^2.0.0",
-		"time-span": "^3.0.0",
+		"@babel/eslint-parser": "^7.14.4",
+		"@babel/plugin-syntax-top-level-await": "^7.12.13",
+		"ava": "^3.15.0",
+		"delay": "^5.0.0",
+		"in-range": "^3.0.0",
+		"time-span": "^5.0.0",
 		"tsd": "^0.16.0",
-		"xo": "^0.24.0"
+		"xo": "^0.40.1"
+	},
+	"xo": {
+		"parser": "@babel/eslint-parser",
+		"parserOptions": {
+			"requireConfigFile": false,
+			"babelOptions": {
+				"plugins": [
+					"@babel/plugin-syntax-top-level-await"
+				]
+			}
+		}
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -13,40 +13,6 @@ $ npm install p-progress
 ## Usage
 
 ```js
-import {PProgress} from 'p-progress';
-
-const progressPromise = new PProgress((resolve, reject, progress) => {
-	const job = new Job();
-
-	job.on('data', data => {
-		progress(data.length / job.totalSize);
-	});
-
-	job.on('finish', resolve);
-	job.on('error', reject);
-});
-
-progressPromise.onProgress(progress => {
-	console.log(`${progress * 100}%`);
-	//=> 9%
-	//=> 23%
-	//=> 59%
-	//=> 75%
-	//=> 100%
-});
-
-await progressPromise;
-```
-
-## API
-
-### pProgress(function)
-
-Convenience method to make your promise-returning or async function report progress.
-
-The function you specify will be passed the `progress()` function as a parameter.
-
-```js
 import pProgress from 'p-progress';
 
 const runJob = async name => pProgress(async progress => {
@@ -70,6 +36,14 @@ progressPromise.onProgress(console.log);
 
 await progressPromise;
 ```
+
+## API
+
+### pProgress(function)
+
+Convenience method to make your promise-returning or async function report progress.
+
+The function you specify will be passed the `progress()` function as a parameter.
 
 ### instance = new PProgress(executor)
 
@@ -99,6 +73,32 @@ The current progress percentage of the promise as a number between 0 and 1.
 #### instance.onProgress(function)
 
 Accepts a function that gets `instance.progress` as an argument and is called for every progress event.
+
+```js
+import {PProgress} from 'p-progress';
+
+const progressPromise = new PProgress((resolve, reject, progress) => {
+	const job = new Job();
+
+	job.on('data', data => {
+		progress(data.length / job.totalSize);
+	});
+
+	job.on('finish', resolve);
+	job.on('error', reject);
+});
+
+progressPromise.onProgress(progress => {
+	console.log(`${progress * 100}%`);
+	//=> 9%
+	//=> 23%
+	//=> 59%
+	//=> 75%
+	//=> 100%
+});
+
+await progressPromise;
+```
 
 ### PProgress.all(promises, options?)
 


### PR DESCRIPTION
Fixes #18, Fixes #15